### PR TITLE
Sym 205 create tests for chat stream component

### DIFF
--- a/src/components/chat-stream.test.tsx
+++ b/src/components/chat-stream.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import ChatStream from './chat-stream'
+import { describe, it, expect } from 'vitest'
+
+const teacherChat = { id: '1', text: 'Hello from teacher!', user: 'teacher', position: 1 }
+const studentChatText = { id: '2', text: 'Hello from student!', user: 'student', position: 1 }
+const studentChatAudio = { id: '3', text: 'blob:http://localhost/audio', user: 'student', position: 1 }
+
+describe('ChatStream Component', () => {
+    it('renders teacher message correctly', () => {
+        render(<ChatStream chatStream={[teacherChat]} />)
+        const message = screen.getByText(teacherChat.text)
+        expect(message).toBeInTheDocument()
+    })
+
+    it('renders student text message correctly', () => {
+        render(<ChatStream chatStream={[studentChatText]} />)
+        const message = screen.getByText(studentChatText.text)
+        expect(message).toBeInTheDocument()
+    })
+
+    it('renders audio element for student audio message', () => {
+        render(<ChatStream chatStream={[studentChatAudio]} />)
+        const audio = screen.getByTestId('audio-element')
+        expect(audio).toBeInTheDocument()
+        expect(audio).toHaveAttribute('src', studentChatAudio.text)
+    })
+})

--- a/src/components/chat-stream.tsx
+++ b/src/components/chat-stream.tsx
@@ -47,7 +47,10 @@ export default function ChatStream({ chatStream }: { chatStream: ChatStreamProps
                                                     {
                                                         chat.text.startsWith('blob:') ? (
                                                             <>
-                                                                <audio className='h-10 border border-gray-300 rounded-full shadow shadow-gray-200' src={chat.text} controls></audio>
+                                                                <audio
+                                                                    data-testid="audio-element"
+                                                                    className='h-10 border border-gray-300 rounded-full shadow shadow-gray-200'
+                                                                    src={chat.text} controls></audio>
                                                             </>
                                                         )
                                                             :

--- a/src/components/chat-stream.tsx
+++ b/src/components/chat-stream.tsx
@@ -5,7 +5,7 @@ import { RefObject, useEffect, useRef } from "react"
 export default function ChatStream({ chatStream }: { chatStream: ChatStreamProps[] }) {
 
     //* Ref to the placeholder div at the end of the stream
-    const scrollRef: RefObject<HTMLDivElement> = useRef(null)
+    const scrollRef: RefObject<HTMLDivElement | null> = useRef(null)
 
     //* Effect to scroll to the last div on the stream when chatStream gets updated
     useEffect(() => {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,8 @@
 import { expect } from 'vitest'
 import * as matchers from '@testing-library/jest-dom/matchers'
 
+if (typeof window !== 'undefined') {
+    window.HTMLElement.prototype.scrollIntoView = () => { }
+}
+
 expect.extend(matchers)


### PR DESCRIPTION
This pull request introduces some new tests for the `ChatStream` component and includes some minor changes to the component itself to support these tests. The most important changes are summarized below:

### New Tests for `ChatStream` Component:

* Added a test suite for the `ChatStream` component using `@testing-library/react` and `vitest`. The tests verify that teacher and student messages are rendered correctly, and that an audio element is rendered for student audio messages. (`src/components/chat-stream.test.tsx`)

### Minor Changes to `ChatStream` Component:

* Updated the type of `scrollRef` to be `RefObject<HTMLDivElement | null>` to avoid potential type issues. (`src/components/chat-stream.tsx`)
* Added a `data-testid` attribute to the audio element in the `ChatStream` component to facilitate testing. (`src/components/chat-stream.tsx`)

### Setup for Testing Environment:

* Added a polyfill for `scrollIntoView` in the `vitest.setup.ts` file to prevent errors in a non-browser environment. (`vitest.setup.ts`)